### PR TITLE
[Configuration] fixed redirect_uris

### DIFF
--- a/src/oidcrp/util.py
+++ b/src/oidcrp/util.py
@@ -312,6 +312,8 @@ def replace(config, param, **kwargs):
                 for _re in res:
                     if "{{{}}}".format(_key) in _re:
                         _lst.append(_re.format(**kwargs))
+                    else:
+                        _lst.append(_re)
                 config[lc_param] = _lst
             else:
                 if "{{{}}}".format(_key) in res:


### PR DESCRIPTION
Without this commit only redirect_uris values with template tags {domain} and {port} would define correctly defined.