### PR TITLE
Fix for situations with multiple workers and persistent storage

### DIFF
--- a/src/oidcrp/__init__.py
+++ b/src/oidcrp/__init__.py
@@ -824,7 +824,7 @@ class RPHandler(object):
             **userinfo** The collected user information
         """
 
-        client = self.issuer2rp[issuer]
+        client = self.client_setup(issuer)
 
         authorization_response = self.finalize_auth(client, issuer, response)
         if is_error_message(authorization_response):


### PR DESCRIPTION
This is a fix for situations where there are multiple frontend worker processes (different address spaces) and there is a working persistent storage on the services layer.

This code was assuming that a client object was already existent in memory if a finalize call is made referring to it by issuer. But this may not be the case if begin() happened in one worker and finalize() happens in a different one.