### PR TITLE
'keys' attribute in configuration file becomes 'key_conf' 

### DIFF
--- a/example/flask_rp/application.py
+++ b/example/flask_rp/application.py
@@ -13,7 +13,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 def init_oidc_rp_handler(app):
     _rp_conf = app.rp_config
 
-    if _rp_conf.keys:
+    if _rp_conf.key_conf:
         _kj = init_key_jar(**_rp_conf.key_conf)
         _path = _rp_conf.key_conf['public_path']
         # removes ./ and / from the begin of the string

--- a/example/flask_rp/application.py
+++ b/example/flask_rp/application.py
@@ -14,8 +14,8 @@ def init_oidc_rp_handler(app):
     _rp_conf = app.rp_config
 
     if _rp_conf.keys:
-        _kj = init_key_jar(**_rp_conf.keys)
-        _path = _rp_conf.keys['public_path']
+        _kj = init_key_jar(**_rp_conf.key_conf)
+        _path = _rp_conf.key_conf['public_path']
         # removes ./ and / from the begin of the string
         _path = re.sub('^(.)/', '', _path)
     else:


### PR DESCRIPTION
A change that is necessary. Since Configuration is a subclass of dictionary, keys is already a taken attribute name.
So we need to switch from keys to key_conf.

Bumped version.