### PR TITLE
Fix variable substitution in config

### DIFF
--- a/example/flask_rp/wsgi.py
+++ b/example/flask_rp/wsgi.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     _config = create_from_config_file(Configuration,
                                       entity_conf=[{"class": RPConfiguration, "attr": "rp"}],
                                       filename=conf)
+     
+    _config.format(_config, dir_path, domain=_config.domain, port=_config.port)
 
     app = application.oidc_provider_init_app(_config.rp, name, template_folder=template_dir)
     _web_conf = _config.web_conf


### PR DESCRIPTION
Fixes #62 
I'm not sure if `wsgi.py` is the right place to perform the variable substitution, as somehow I feel it is more appropriate to bury it away in the `init_oidc_rp_handler`.