### PR TITLE
WiP: Fix configvar substitution

### DIFF
--- a/example/flask_rp/wsgi.py
+++ b/example/flask_rp/wsgi.py
@@ -24,8 +24,7 @@ if __name__ == "__main__":
     _config = create_from_config_file(Configuration,
                                       entity_conf=[{"class": RPConfiguration, "attr": "rp"}],
                                       filename=conf)
-     
-    _config.format(_config, dir_path, domain=_config.domain, port=_config.port)
+
 
     app = application.oidc_provider_init_app(_config.rp, name, template_folder=template_dir)
     _web_conf = _config.web_conf

--- a/example/flask_rp/wsgi.py
+++ b/example/flask_rp/wsgi.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     _config = create_from_config_file(Configuration,
                                       entity_conf=[{"class": RPConfiguration, "attr": "rp"}],
                                       filename=conf)
+     
+    _config.format(_config, dir_path, domain=_config.domain, port=_config.port)
 
     app = application.oidc_provider_init_app(_config.rp, name, template_folder=template_dir)
     _web_conf = _config.web_conf

--- a/example/flask_rp/wsgi.py
+++ b/example/flask_rp/wsgi.py
@@ -25,7 +25,6 @@ if __name__ == "__main__":
                                       entity_conf=[{"class": RPConfiguration, "attr": "rp"}],
                                       filename=conf)
 
-
     app = application.oidc_provider_init_app(_config.rp, name, template_folder=template_dir)
     _web_conf = _config.web_conf
     context = create_context(dir_path, _web_conf)

--- a/src/oidcrp/configure.py
+++ b/src/oidcrp/configure.py
@@ -24,6 +24,9 @@ URIS = [
 
 
 class RPConfiguration(Base):
+
+    uris = URIS
+    
     def __init__(self,
                  conf: Dict,
                  base_path: Optional[str] = '',
@@ -52,6 +55,7 @@ class RPConfiguration(Base):
         self.services = lower_or_upper(conf, "services")
         self.base_url = lower_or_upper(conf, "base_url")
         self.httpc_params = lower_or_upper(conf, "httpc_params", {"verify": True})
+        self.clients = lower_or_upper(conf, "clients")
 
         if entity_conf:
             self.extend(entity_conf=entity_conf, conf=conf, base_path=base_path,

--- a/tests/test_22_config.py
+++ b/tests/test_22_config.py
@@ -22,6 +22,9 @@ def test_yaml_config():
     assert set(rp_config.services.keys()) == {'discovery', 'registration', 'authorization',
                                               'accesstoken', 'userinfo', 'end_session'}
     assert set(rp_config.clients.keys()) == {'', 'bobcat', 'flop'}
+    assert rp_config.clients['flop']
+    assert rp_config.clients['flop']['redirect_uris']
+    assert set(rp_config.clients['flop']['redirect_uris']) == {'https://127.0.0.1:8090/authz_cb/flop'}
 
 
 def test_dict():

--- a/tests/test_22_config.py
+++ b/tests/test_22_config.py
@@ -22,6 +22,10 @@ def test_yaml_config():
     assert set(rp_config.services.keys()) == {'discovery', 'registration', 'authorization',
                                               'accesstoken', 'userinfo', 'end_session'}
     assert set(rp_config.clients.keys()) == {'', 'bobcat', 'flop'}
+    assert rp_config.clients['flop']
+    assert rp_config.clients['flop']['redirect_uris']
+    assert set(rp_config.clients['flop']['redirect_uris']) == {'https://127.0.0.1:8090/authz_cb/flop'}
+    
 
 
 def test_dict():

--- a/tests/test_22_config.py
+++ b/tests/test_22_config.py
@@ -25,7 +25,6 @@ def test_yaml_config():
     assert rp_config.clients['flop']
     assert rp_config.clients['flop']['redirect_uris']
     assert set(rp_config.clients['flop']['redirect_uris']) == {'https://127.0.0.1:8090/authz_cb/flop'}
-    
 
 
 def test_dict():


### PR DESCRIPTION
Added a testcase to demonstrate that variable substitution does currently not work for deeper levels, e.g. for `clients/flop/redirect_urls`